### PR TITLE
Removed `From<i32>` trait bound in `MergeMedian` impl for `MidpointMedian`

### DIFF
--- a/src/mergemedian.rs
+++ b/src/mergemedian.rs
@@ -99,7 +99,7 @@ impl Default for LeftHandedMedian {
 /// ```
 #[derive(Clone)]
 pub struct MidpointMedian;
-impl<T: Div<Output = T> + Add<T, Output = T> + From<i32> + Copy + One> MergeMedian<T> for MidpointMedian {
+impl<T: Div<Output = T> + Add<T, Output = T> + Copy + One> MergeMedian<T> for MidpointMedian {
   fn merge(&self, a: &T, b: &T) -> T {
       (*a + *b) / (T::one() + T::one())
   }


### PR DESCRIPTION
The trait bound prohibited me from using `MedianHeap` with `u64`s. The tests still work. Was it maybe an artifact from earlier development?